### PR TITLE
fix: adds another nomenclature for validating a "zip" file

### DIFF
--- a/public/js/resource/create-edit.js
+++ b/public/js/resource/create-edit.js
@@ -90,7 +90,10 @@ const listFilesZip = (event) => {
     const file = event.currentTarget.files[0];
     const reader = new FileReader();
 
-    if (file.type == "application/x-zip-compressed") {
+    if (
+        file.type == "application/x-zip-compressed" ||
+        file.type == "application/zip"
+    ) {
         reader.readAsArrayBuffer(file);
 
         reader.onload = (event) => {


### PR DESCRIPTION
With this new nomenclature for validation, it corrects the error when opening the input to select the initialization file.